### PR TITLE
Update test dataset to include more sample images with better resolut…

### DIFF
--- a/src/ess/imaging/data.py
+++ b/src/ess/imaging/data.py
@@ -15,8 +15,8 @@ def _make_pooch():
         base_url='https://public.esss.dk/groups/scipp/ess/imaging/',
         version=_version,
         registry={
-            'small_ymir_images.hdf': 'md5:5fbc52595f3e6117a2be2bb50866806a',
-            'README.md': 'md5:6ca6b4a79bcff2965a81767e12474617',
+            'small_ymir_images.hdf': 'md5:cf83695d5da29e686c10a31b402b8bdb',
+            'README.md': 'md5:0f375972d4008de6060b065ac13ba17f',
         },
     )
 


### PR DESCRIPTION
Fixes #44 

Now it has 36 sample images covering every 10 degrees of rotation angle
with image size 256x256.

Data analysis workflow needed more rotation angles to test their methods.

The file size is ~6 Mb.

The file was tested in the #42 