### PR TITLE
Add small mcstas image files for testing.

### DIFF
--- a/src/ess/imaging/data.py
+++ b/src/ess/imaging/data.py
@@ -4,7 +4,7 @@ import pathlib
 
 import pooch
 
-_version = '0'
+_version = '1'
 
 
 def _make_pooch():
@@ -12,11 +12,13 @@ def _make_pooch():
         path=pooch.os_cache('essimaging'),
         env='BEAMLIME_DATA_DIR',
         retry_if_failed=3,
-        base_url='https://public.esss.dk/groups/scipp/ess/imaging/',
+        base_url=f'https://public.esss.dk/groups/scipp/ess/imaging/{_version}/',
         version=_version,
         registry={
+            'small_mcstas_ob_images.h5': 'md5:2f181bbacb164c28bfaf7cce09701d92',
+            'small_mcstas_sample_images.h5': 'md5:3c42570951cabec7caedc76d90d03fa3',
             'small_ymir_images.hdf': 'md5:cf83695d5da29e686c10a31b402b8bdb',
-            'README.md': 'md5:0f375972d4008de6060b065ac13ba17f',
+            'README.md': 'md5:9e1beeb325f127d691a8d7882db3255d',
         },
     )
 
@@ -42,3 +44,19 @@ def get_ymir_images_path() -> pathlib.Path:
     """
 
     return get_path('small_ymir_images.hdf')
+
+
+def get_mcstas_ob_images_path() -> pathlib.Path:
+    """
+    Return the path to the small McStas OB images HDF5 file.
+    """
+
+    return get_path('small_mcstas_ob_images.h5')
+
+
+def get_mcstas_sample_images_path() -> pathlib.Path:
+    """
+    Return the path to the small McStas sample images HDF5 file.
+    """
+
+    return get_path('small_mcstas_sample_images.h5')


### PR DESCRIPTION
Related to #32 

Added two files for `open-beam`(background) and `sample`.

They are subset of actual files from [nextcloud](https://project.esss.dk/nextcloud/index.php/apps/files/?dir=/McStas_ODIN&fileid=18487919)