### PR TITLE
Ignore plotting related warning.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ addopts = """
 testpaths = "tests"
 filterwarnings = [
   "error",
+  # Plotting related warnings.
+  'ignore:\n            Sentinel is not a public part of the traitlets API:DeprecationWarning'
 ]
 
 [tool.ruff]


### PR DESCRIPTION
When loading `GenericWorkflow` from `scippneutron`, the `pythreejs` causes deprecation warning, 
so nightly test fails: https://github.com/scipp/essimaging/actions/runs/12022756225/job/33515498925

So I copied the warning filter from `scippneutron`: https://github.com/scipp/scippneutron/blob/main/pyproject.toml to essimaging.
