### PR TITLE
Fix documentation regarding pixel masking in Ymir workflow.

### DIFF
--- a/src/ess/imaging/io.py
+++ b/src/ess/imaging/io.py
@@ -48,7 +48,7 @@ DarkCurrentImageStacks = NewType("DarkCurrentImageStacks", sc.DataArray)
 IMAGE_KEY_COORD_NAME = "image_key"
 """Image key coordinate name."""
 TIME_COORD_NAME = "time"
-"""Time coordinate name."""
+"""Time coordinate name. **Note that it is not time of flight.**"""
 ROTATION_ANGLE_COORD_NAME = "rotation_angle"
 """Rotation angle coordinate name."""
 DIM1_COORD_NAME = "dim_1"

--- a/src/ess/imaging/workflow.py
+++ b/src/ess/imaging/workflow.py
@@ -72,6 +72,14 @@ def YmirImageNormalizationWorkflow() -> sl.Pipeline:
     """
     Ymir histogram mode imaging normalization workflow.
 
+    .. note:: `time` dimension is not `time-of-flight` but the wall-clock time.
+
+    Returns
+    -------
+    :
+        Workflow pipeline object for multiple Ymir histogram mode images reduction.
+
+
     Default Normalization Formula
     -----------------------------
 
@@ -91,18 +99,15 @@ def YmirImageNormalizationWorkflow() -> sl.Pipeline:
 
         \\text{where } i \\text{ is an index of an image.}
 
-        \\text{Pixel values less than sample_threshold}
-
-        \\text{ are replaced with sample_threshold}.
+        \\text{Pixel values less than sample_threshold are masked.}
 
     .. math::
 
         BackgroundImage = mean(OpenBeam, dim=\\text{'time'})
         - mean(DarkCurrent, dim=\\text{'time'})
 
-        \\text{Pixel values less than } \\text{background_threshold}
+        \\text{Pixel values less than background_threshold are masked}
 
-        \\text{ are replaced with } \\text{background_threshold}.
     """
     return sl.Pipeline(
         (*_IO_PROVIDERS, *_NORMALIZATION_PROVIDERS),


### PR DESCRIPTION
Related to #77 
As the threshold applying function has changed in the workflow, the documentation also needs to be updated.
(Ymir workflow is not about time of flight. It's only for optical imaging.)

