### PR TITLE
fix: replace data path function

### DIFF
--- a/tests/imaging/tools/analysis_test.py
+++ b/tests/imaging/tools/analysis_test.py
@@ -24,7 +24,7 @@ def test_resample() -> None:
 
 
 def test_resample_with_position_coord() -> None:
-    da = load_scitiff(get_siemens_star_path())["image"]
+    da = load_scitiff(siemens_star_path())["image"]
     vectors = np.random.randn(*da.shape[1:], 3)
     da.coords['position'] = sc.vectors(dims=['x', 'y'], values=vectors)
     resampled = img.tools.resample(da, sizes={'x': 2, 'y': 2})


### PR DESCRIPTION
The `get_siemens_star_path` does not seem to exist, and this causes an error in the nightly on main: https://github.com/scipp/essimaging/actions/runs/18703808207/job/53337775945#step:6:101

Not sure why this wasn't caught by CI.