### PR TITLE
Keep coordinates after resizing/resampling.

### DIFF
--- a/src/ess/imaging/tools/analysis.py
+++ b/src/ess/imaging/tools/analysis.py
@@ -94,10 +94,10 @@ def resample(
     -----
     If the image is a ``scipp.DataArray``,
     bin edges in the resampling dimensions
-    will be preserved if they are 1-dimensional and sorted.
+    will be preserved if they are 1-dimensional and sorted (they are dropped otherwise).
     New bin edges will be chosen according to the resampling sizes.
-    For other coordinates, new coordinates will be average values
-    of each resampled blocks.
+    For midpoint coordinates, new coordinates will be average values
+    of each resampled block.
 
     .. warning::
         The coordinates in the output may not be correct

--- a/src/ess/imaging/tools/analysis.py
+++ b/src/ess/imaging/tools/analysis.py
@@ -102,10 +102,9 @@ def resample(
             if _is_1d_sorted_bin_edge(image, keep_coordinate):
                 orig_dim = next(iter(image.coords[keep_coordinate].dims))
                 reduced_dim = next(iter(reduced_dims))
-                out.coords[keep_coordinate] = sc.concat(
-                    [coord.min(reduced_dim), coord.max(dim=reduced_dim)],
-                    dim=orig_dim,
-                )
+                out.coords[keep_coordinate] = image.coords[keep_coordinate][
+                    orig_dim, :: blocked.sizes[reduced_dim]
+                ]
             elif _has_bin_edge(image, keep_coordinate):
                 ...
             else:

--- a/src/ess/imaging/tools/analysis.py
+++ b/src/ess/imaging/tools/analysis.py
@@ -178,8 +178,7 @@ def resize(
                 f"Size of dimension '{dim}' ({image.sizes[dim]}) is not divisible by"
                 f" the requested size ({size})."
             )
-        if (_resample_size := image.sizes[dim] // size) != 1:
-            block_sizes[dim] = _resample_size
+        block_sizes[dim] = image.sizes[dim] // size
 
     return resample(image, sizes=block_sizes, method=method)
 

--- a/src/ess/imaging/tools/analysis.py
+++ b/src/ess/imaging/tools/analysis.py
@@ -102,7 +102,7 @@ def resample(
     # Filter the resample sizes first.
     sizes = {dim: size for dim, size in sizes.items() if size != 1}
     if not sizes:
-        return image.copy()
+        return image.copy(deep=False)
 
     blocked = blockify(image, sizes=sizes)
     _method = getattr(sc, method) if isinstance(method, str) else method

--- a/src/ess/imaging/tools/analysis.py
+++ b/src/ess/imaging/tools/analysis.py
@@ -55,7 +55,7 @@ def resample(
     image: sc.Variable | sc.DataArray,
     sizes: dict[str, int],
     method: str | Callable = 'sum',
-    keep: tuple[str, ...] = ('position',),
+    keep: tuple[str, ...] = (),
 ) -> sc.Variable | sc.DataArray:
     """
     Resample an image by folding it into blocks of specified sizes and applying a
@@ -117,7 +117,7 @@ def resize(
     image: sc.Variable | sc.DataArray,
     sizes: dict[str, int],
     method: str | Callable = 'sum',
-    keep: tuple[str, ...] = ('position',),
+    keep: tuple[str, ...] = (),
 ) -> sc.Variable | sc.DataArray:
     """
     Resize an image by folding it into blocks of specified sizes and applying a

--- a/src/ess/imaging/tools/analysis.py
+++ b/src/ess/imaging/tools/analysis.py
@@ -179,7 +179,6 @@ def resize(
                 f" the requested size ({size})."
             )
         block_sizes[dim] = image.sizes[dim] // size
-
     return resample(image, sizes=block_sizes, method=method)
 
 

--- a/src/ess/imaging/tools/analysis.py
+++ b/src/ess/imaging/tools/analysis.py
@@ -39,14 +39,16 @@ def blockify(
 
 def _is_1d_sorted_bin_edge(img: sc.DataArray, coord_name: str) -> bool:
     orig_coord = img.coords[coord_name]
-    return len(orig_coord.dims) == 1 and (
-        len(orig_coord) == img.sizes[orig_coord.dim] + 1
+    return (
+        len(orig_coord.dims) == 1
+        and bool(sc.issorted(orig_coord, dim=orig_coord.dim, order='ascending'))
+        and (len(orig_coord) == img.sizes[orig_coord.dim] + 1)
     )
 
 
 def _has_bin_edge(img: sc.DataArray, coord_name: str) -> bool:
     orig_coord = img.coords[coord_name]
-    return any(orig_coord.sizes[dim] == img.sizes[dim] + 1 for dim in orig_coord.dims)
+    return any(img.coords.is_edges(coord_name, dim) for dim in orig_coord.dims)
 
 
 def resample(

--- a/tests/imaging/tools/analysis_test.py
+++ b/tests/imaging/tools/analysis_test.py
@@ -24,6 +24,13 @@ def test_resample() -> None:
     assert resampled.sizes['y'] == da.sizes['y'] // 2
 
 
+def test_resample_with_sizes_1() -> None:
+    da = load_scitiff(siemens_star_path())["image"]
+    resampled = img.tools.resample(da, sizes=dict.fromkeys(da.dims, 1))
+    assert_identical(resampled, da)
+    assert da is not resampled
+
+
 def test_resample_with_2d_position_coord() -> None:
     da = load_scitiff(siemens_star_path())["image"]
     vectors = np.random.randn(*da.shape[1:], 3)
@@ -116,6 +123,13 @@ def test_resize_callable() -> None:
     resized = img.tools.resize(da, sizes={'x': 256, 'y': 256}, method=sc.max)
     assert resized.sizes['x'] == 256
     assert resized.sizes['y'] == 256
+
+
+def test_resize_same_sizes() -> None:
+    da = load_scitiff(siemens_star_path())["image"]
+    resized = img.tools.resize(da, sizes=da.sizes)
+    assert_identical(resized, da)
+    assert da is not resized
 
 
 def test_resize_keep_coordinate() -> None:

--- a/tests/imaging/tools/analysis_test.py
+++ b/tests/imaging/tools/analysis_test.py
@@ -53,6 +53,14 @@ def test_resample_keep_bin_edge_coordinate() -> None:
     assert_identical(expected_x, resampled.coords['t'])
 
 
+def test_resample_keep_unsorted_bin_edge_coordinate_ignored() -> None:
+    da = load_scitiff(siemens_star_path())["image"]
+    # Overwrite the coordinate 't' to be a bin-edge.
+    da.coords['t'] = sc.array(dims=['t'], values=[0, 1, 3, 2])
+    resampled = img.tools.resample(da, sizes={'x': 2, 'y': 2, 't': 3}, keep=('t',))
+    assert 't' not in resampled.coords
+
+
 def test_resample_mean() -> None:
     da = load_scitiff(siemens_star_path())["image"]
     resampled = img.tools.resample(da, sizes={'x': 2, 'y': 2}, method='mean')

--- a/tests/imaging/tools/analysis_test.py
+++ b/tests/imaging/tools/analysis_test.py
@@ -36,13 +36,22 @@ def test_resample_with_2d_position_coord() -> None:
     )
 
 
+def test_resample_keep_coordinate() -> None:
+    da = load_scitiff(siemens_star_path())["image"]
+    # Overwrite the coordinate 't' to be a bin-edge.
+    da.coords['t'] = sc.array(dims=['t'], values=[1, 2, 3])
+    resampled = img.tools.resample(da, sizes={'x': 2, 'y': 2, 't': 3})
+    expected_t = sc.array(dims=['t'], values=[2.0], unit='dimensionless')
+    assert_identical(expected_t, resampled.coords['t'])
+
+
 def test_resample_keep_bin_edge_coordinate() -> None:
     da = load_scitiff(siemens_star_path())["image"]
     # Overwrite the coordinate 't' to be a bin-edge.
     da.coords['t'] = sc.array(dims=['t'], values=[0, 1, 2, 3])
     resampled = img.tools.resample(da, sizes={'x': 2, 'y': 2, 't': 3})
-    expected_x = sc.array(dims=['t'], values=[0, 3], unit='dimensionless')
-    assert_identical(expected_x, resampled.coords['t'])
+    expected_t = sc.array(dims=['t'], values=[0, 3], unit='dimensionless')
+    assert_identical(expected_t, resampled.coords['t'])
 
 
 def test_resample_unsorted_bin_edge_coordinate_ignored() -> None:
@@ -109,13 +118,22 @@ def test_resize_callable() -> None:
     assert resized.sizes['y'] == 256
 
 
+def test_resize_keep_coordinate() -> None:
+    da = load_scitiff(siemens_star_path())["image"]
+    # Overwrite the coordinate 't' to be a bin-edge.
+    da.coords['t'] = sc.array(dims=['t'], values=[1, 2, 3])
+    resampled = img.tools.resize(da, sizes={'t': 1})
+    expected_t = sc.array(dims=['t'], values=[2.0], unit='dimensionless')
+    assert_identical(expected_t, resampled.coords['t'])
+
+
 def test_resize_keep_bin_edge_coordinate() -> None:
     da = load_scitiff(siemens_star_path())["image"]
     # Overwrite the coordinate 't' to be a bin-edge.
     da.coords['t'] = sc.array(dims=['t'], values=[0, 1, 2, 3])
     resized = img.tools.resize(da, sizes={'x': 256, 'y': 256, 't': 1})
-    expected_x = sc.array(dims=['t'], values=[0, 3], unit='dimensionless')
-    assert_identical(expected_x, resized.coords['t'])
+    expected_t = sc.array(dims=['t'], values=[0, 3], unit='dimensionless')
+    assert_identical(expected_t, resized.coords['t'])
 
 
 def test_resize_unsorted_bin_edge_ignored() -> None:

--- a/tests/imaging/tools/analysis_test.py
+++ b/tests/imaging/tools/analysis_test.py
@@ -28,7 +28,7 @@ def test_resample_with_position_coord() -> None:
     da = load_scitiff(siemens_star_path())["image"]
     vectors = np.random.randn(*da.shape[1:], 3)
     da.coords['position'] = sc.vectors(dims=['x', 'y'], values=vectors)
-    resampled = img.tools.resample(da, sizes={'x': 2, 'y': 2})
+    resampled = img.tools.resample(da, sizes={'x': 2, 'y': 2}, keep=('position',))
     ny, nx = resampled.shape[1:]
     np.testing.assert_allclose(
         resampled.coords['position'].values,


### PR DESCRIPTION
Fixes scipp/ess#21 

I limited the scope of coordinate handling to keep it simple.
We can always handle the coordinates separately in more complicated situations if needed.

@nvaytet can you please have a look...?