### PR TITLE
fix: make max-resolution tool work with binned input

### DIFF
--- a/src/ess/imaging/tools/resolution.py
+++ b/src/ess/imaging/tools/resolution.py
@@ -7,7 +7,6 @@ def maximum_resolution_achievable(
     events: sc.DataArray,
     coarse_x_bin_edges: sc.Variable,
     coarse_y_bin_edges: sc.Variable,
-    time_bin_edges: sc.Variable,
     max_tries: int = 10,
     max_pixels_x: int = 2048,
     max_pixels_y: int = 2048,
@@ -31,8 +30,6 @@ def maximum_resolution_achievable(
         Minimum acceptable resolution in ``x``.
     coarse_y_bin_edges:
         Minimum acceptable resolution in ``y``.
-    time_bin_edges:
-        Desired resolution in ``t``.
     max_tries:
         The maximum number of iterations before giving up.
     max_pixels_x:
@@ -60,13 +57,16 @@ def maximum_resolution_achievable(
     nx = int(2**0.5 * lower_nx) + 1
     ny = int(2**0.5 * lower_ny) + 1
 
-    if events.bins is not None:
-        events = events.copy(deep=False)
-        # Add the x and y coords as event coordinates.
-        for c in (coarse_x_bin_edges.dim, coarse_y_bin_edges.dim):
-            events.bins.coords[c] = sc.bins_like(events, sc.midpoints(events.coords[c]))
+    events = events.copy(deep=False)
 
-    events = events.bin({time_bin_edges.dim: time_bin_edges}, dim=events.dims)
+    if events.bins is not None:
+        image_dims = (coarse_x_bin_edges.dim, coarse_y_bin_edges.dim)
+        for c in image_dims:
+            if c not in events.bins.coords:
+                events.bins.coords[c] = sc.bins_like(
+                    events, sc.midpoints(events.coords[c])
+                )
+        events = events.bins.concat(image_dims)
 
     for _ in range(max_tries):
         xbins = sc.linspace(
@@ -95,7 +95,7 @@ def maximum_resolution_achievable(
             upper_nx = nx
             upper_ny = ny
             nx = min(round((lower_nx * nx) ** 0.5), upper_nx - 1)
-            ny = min(round((lower_ny * ny) ** 0.5), upper_nx - 1)
+            ny = min(round((lower_ny * ny) ** 0.5), upper_ny - 1)
 
         if upper_nx - lower_nx < 2 and upper_ny - lower_ny < 2:
             break

--- a/src/ess/imaging/tools/resolution.py
+++ b/src/ess/imaging/tools/resolution.py
@@ -59,7 +59,14 @@ def maximum_resolution_achievable(
 
     nx = int(2**0.5 * lower_nx) + 1
     ny = int(2**0.5 * lower_ny) + 1
-    events = events.bin({time_bin_edges.dim: time_bin_edges})
+
+    if events.bins is not None:
+        events = events.copy(deep=False)
+        # Add the x and y coords as event coordinates.
+        for c in (coarse_x_bin_edges.dim, coarse_y_bin_edges.dim):
+            events.bins.coords[c] = sc.bins_like(events, sc.midpoints(events.coords[c]))
+
+    events = events.bin({time_bin_edges.dim: time_bin_edges}, dim=events.dims)
 
     for _ in range(max_tries):
         xbins = sc.linspace(

--- a/tests/imaging/tools/maximum_resolution_monitor_tests.py
+++ b/tests/imaging/tools/maximum_resolution_monitor_tests.py
@@ -70,3 +70,47 @@ def test_finds_maximum_resolution_random(seed):
         .value
         == 0
     )
+
+
+def test_finds_maximum_resolution_binned_input():
+    np.random.seed(0)
+    n = np.random.randint(1000, 100_000)
+    events = sc.DataArray(
+        sc.ones(dims=['events'], shape=(n,)),
+        coords={
+            'x': sc.array(dims=['events'], values=np.random.random(n)),
+            'y': sc.array(dims=['events'], values=np.random.random(n)),
+            't': sc.array(dims=['events'], values=np.random.random(n)),
+        },
+    )
+    events = events.bin(x=4000, y=4000)
+    del events.bins.coords['x']
+    del events.bins.coords['y']
+    x_be, y_be = maximum_resolution_achievable(
+        events,
+        sc.linspace('x', 0, 1, 2),
+        sc.linspace('y', 0, 1, 2),
+        sc.linspace('t', 0, 1, 500),
+        # Need enough tries to be sure we find the optimum
+        max_tries=100,
+    )
+
+    assert (
+        events.bin(x=x_be, y=y_be, t=sc.linspace('t', 0, 1, 500), dim=events.dims)
+        .bins.size()
+        .min()
+        .value
+        > 0
+    )
+    assert (
+        events.bin(
+            x=sc.linspace('x', 0, 1, len(x_be) + 1),
+            y=sc.linspace('y', 0, 1, len(y_be) + 1),
+            t=sc.linspace('t', 0, 1, 500),
+            dim=events.dims,
+        )
+        .bins.size()
+        .min()
+        .value
+        == 0
+    )

--- a/tests/imaging/tools/maximum_resolution_monitor_tests.py
+++ b/tests/imaging/tools/maximum_resolution_monitor_tests.py
@@ -25,7 +25,6 @@ def test_finds_maximum_resolution():
         events,
         sc.linspace('x', 0, 1, 2),
         sc.linspace('x', 0, 1, 2),
-        sc.linspace('t', 0, 2, 2),
     )
     assert len(x_be) == 11
     assert len(y_be) == 11
@@ -51,7 +50,6 @@ def test_finds_maximum_resolution_random(seed):
         events,
         sc.linspace('x', 0, 1, 2),
         sc.linspace('y', 0, 1, 2),
-        sc.linspace('t', 0, 2, 2),
         # Need enough tries to be sure we find the optimum
         max_tries=100,
     )
@@ -83,31 +81,26 @@ def test_finds_maximum_resolution_binned_input():
             't': sc.array(dims=['events'], values=np.random.random(n)),
         },
     )
-    events = events.bin(x=4000, y=4000)
+    events = events.bin(x=100, y=100, t=500)
     del events.bins.coords['x']
     del events.bins.coords['y']
     x_be, y_be = maximum_resolution_achievable(
         events,
         sc.linspace('x', 0, 1, 2),
         sc.linspace('y', 0, 1, 2),
-        sc.linspace('t', 0, 1, 500),
         # Need enough tries to be sure we find the optimum
         max_tries=100,
     )
 
-    assert (
-        events.bin(x=x_be, y=y_be, t=sc.linspace('t', 0, 1, 500), dim=events.dims)
-        .bins.size()
-        .min()
-        .value
-        > 0
-    )
+    events.bins.coords['x'] = sc.bins_like(events, sc.midpoints(events.coords['x']))
+    events.bins.coords['y'] = sc.bins_like(events, sc.midpoints(events.coords['y']))
+    events = events.bins.concat(['x', 'y'])
+
+    assert events.bin(x=x_be, y=y_be).bins.size().min().value > 0
     assert (
         events.bin(
             x=sc.linspace('x', 0, 1, len(x_be) + 1),
             y=sc.linspace('y', 0, 1, len(y_be) + 1),
-            t=sc.linspace('t', 0, 1, 500),
-            dim=events.dims,
         )
         .bins.size()
         .min()


### PR DESCRIPTION
Previously the method assumed non-binned input.